### PR TITLE
Update wrpstats.h

### DIFF
--- a/wrpstats.h
+++ b/wrpstats.h
@@ -19,8 +19,8 @@ private:
     float cellsize, elevation, dDir[3][4];
     int len, texturegrid, terraingrid;
     long noofmaterials;
-    short materialindex, materiallenght;
-    ulong dObjIndex;
+    short materialindex;
+    ulong dObjIndex, materiallenght;
 };
 
 #endif // WRPSTATS_H


### PR DESCRIPTION
Was reading value of size 4 into a short which is size 2
Materiallength is actually a unsigned long  https://community.bistudio.com/wiki/Wrp_File_Format_-_8WVR